### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/MOHAMMAD3230/Diet_i_c_ian/security/code-scanning/1](https://github.com/MOHAMMAD3230/Diet_i_c_ian/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the `build` job in `.github/workflows/npm-publish-github-packages.yml`. This block should specify `contents: read`, which is the minimal permission required for most build and test jobs that only need to check out code and do not need to write to the repository or access packages. This change should be made directly under the `build:` job definition, before the `runs-on` key (i.e., at line 12). No other changes are needed, as the `publish-gpr` job already has the correct permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
